### PR TITLE
Add create list from string for method `l` when called with one argument.

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -3,6 +3,7 @@ module.exports = function(less) {
 
     var tree       = less.tree,
         Expression = tree.Expression,
+        Quoted     = tree.Quoted,
         Anonymous  = tree.Anonymous,
         Value      = tree.Value,
         Node       = tree.Node,
@@ -51,7 +52,7 @@ module.exports = function(less) {
         list = (!isArray(list.value[0].value) &&
             (list.type === "Expression"))
                 ? [list] : list.value;
-
+        
         var pair, type, key;
         for (var i = 0; i < list.length; i++) {
             pair = list[i];
@@ -111,8 +112,24 @@ module.exports = function(less) {
 
         l: function() {
             if (arguments.length < 2)
+            {
+                if (typeof arguments[0].value === "string")
+                {
+                    var list = arguments[0].value.split (",");
+                    for (var i = 0; i < list.length; i++)
+                    {
+                        list[i] = list[i].split (" ");
+                        for (var j = 0; j < list[i].length; j++)
+                        {
+                            list[i][j] = new Quoted ('"', list[i][j], true);
+                        }
+                        list[i] = new Expression (list[i]);
+                    }
+                    return newLessList (list);
+                }
                 return;
-
+            }
+            
             var list = new Array(arguments.length);
             for (var i = 0; i < arguments.length; i++)
                 list[i] = arguments[i];


### PR DESCRIPTION
The method l now converts a given string to an array when it gets called
with one argument of type string.

This is useful when generating a dictionary in a less javascript block:

``` less
@dict: l(`(function () { return "key1 value1, key2 value2"; })()`);

.selector {
  property: at(@dict, value1);
}
```
